### PR TITLE
[ch3041] Add support for multiple hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ following arguments:
 * `-p` or `--listen-port`: HTTP port to listen on
 * `-H` or `--riemann-host`: Address where the riemann index lives
 * `-P` or `--riemann-port`: Port the index listens on
+* `-S` or `--riemann-hosts`: For multiple indexes, e.g. '--riemann-hosts server1.example.com:5555,server2.example.com:5757'
 * `-e` or `--environment`: Enable some debugging if set to "development"
 * `-h` or `--help`: display help and exit
 
 ## Caveats
 
-This first release is rough around the edges, it was 
+This first release is rough around the edges, it was
 put together in about a day, please mind the following
 issues:
 


### PR DESCRIPTION
I have a newer version of this in progress that does server calls in parallel, and uses ClojureScript and React on the UI, but in the meantime, this PR adds basic support for querying multiple hosts and aggregating the results.

It introduces a new argument `--riemann-hosts` which takes precedence over `--riemann-host`. I left the single host format to not break the existing API.

```
--riemann-hosts server1.example.com:5555,server2.example.com:5757
``` 